### PR TITLE
chore: prepare to archive repo

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,8 +7,8 @@ on:
     branches: [ "main" ]
     paths-ignore:
       - '**/*.md'
-  schedule:
-    - cron: '32 07 * * 3'
+  # schedule:
+  #   - cron: '32 07 * * 3'
 
 permissions: {}
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,8 +1,8 @@
 name: Scorecard OSSF
 on:
   branch_protection_rule:
-  schedule:
-    - cron: '32 07 * * 4'
+  # schedule:
+  #   - cron: '32 07 * * 4'
   push:
     branches: [ "main" ]
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Welcome to Remix!
+# Remix Baseline in Turborepo (Archived)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/grendel-consulting/remix-baseline/badge)](https://scorecard.dev/viewer/?uri=github.com/grendel-consulting/remix-baseline)
 
 Batteries-included baseline for Remix

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "enabled": false,
   "extends": [
     "config:best-practices",
     "schedule:nonOfficeHours",


### PR DESCRIPTION
Archiving repo as no ongoing or anticipated projects using Remix; this is preparation to limit third-party activities on the repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Workflow Updates**
  - Disabled scheduled CodeQL and Scorecard workflow runs
- **Project Status**
  - Updated README to indicate project is archived
- **Dependency Management**
  - Disabled Renovate bot for automatic dependency updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->